### PR TITLE
fix bug in sparse modules

### DIFF
--- a/recsys/hybrid_parallel_main.py
+++ b/recsys/hybrid_parallel_main.py
@@ -177,7 +177,7 @@ def _train(model,
     model.train()
     data_iter = iter(data_loader)
     samples_per_trainer = len(data_loader) / dist_manager.get_world_size() * epochs
-    rank = dist_manager.get_rank(),
+    rank = dist_manager.get_rank()
     world_size = dist_manager.get_world_size()
     for it in tqdm(itertools.count(), desc=f"Epoch {epoch}"):
         try:

--- a/run.sh
+++ b/run.sh
@@ -13,7 +13,7 @@
 #    --learning_rate 1. --batch_size 16384 --use_sparse_embed_grad #--use_cpu  #--change_lr
 
 # For hybrid parallelism
-torchx run -s local_cwd -cfg log_dir=tmp dist.ddp -j 1x2 --script recsys/main.py -- --kaggle \
+torchx run -s local_cwd -cfg log_dir=tmp dist.ddp -j 1x2 --script recsys/hybrid_parallel_main.py -- --kaggle \
     --in_memory_binary_criteo_path criteo_kaggle --embedding_dim 128 --pin_memory \
     --over_arch_layer_sizes "1024,1024,512,256,1" --dense_arch_layer_sizes "512,256,128" --epochs 1 --shuffle_batches \
-    --learning_rate 1. --batch_size 16384 --use_sparse_embed_grad #--use_cpu  #--change_lr
+    --learning_rate 1. --batch_size 16384 --use_sparse_embed_grad #--use_cpu #--change_lr


### PR DESCRIPTION
之前run.sh执行的脚本错了，改成hybrid_parallel_main.py之后，发现还有几处bug：
1. sparse module里.view()的batch size维度，随all_to_all之后应该变成1/world_size；
2. 一些typo  

修改后能保证训练收敛，benchmark进行中