### PR TITLE
Cache embedding python

### DIFF
--- a/recsys/modules/embeddings/__init__.py
+++ b/recsys/modules/embeddings/__init__.py
@@ -4,10 +4,11 @@ from .pep_embedding import PEPEmbeddingBag
 from .parallel_embeddings import (VocabParallelEmbedding, ColumnParallelEmbeddingBag, FusedHybridParallelEmbeddingBag,
                                   ParallelQREmbedding)
 from .parallel_mix_vocab_embedding import LoadBalanceManager, ParallelMixVocabEmbeddingBag, BlockEmbeddingBag
-from .cached_embeddings import CacheReplacePolicy, CachedEmbeddingBag
+from .cached_embeddings import CacheReplacePolicy, CachedEmbeddingBag, ParallelCachedEmbeddingBag
 
 __all__ = [
     'MixDimensionEmbeddingBag', 'QREmbeddingBag', 'PEPEmbeddingBag', 'VocabParallelEmbedding',
     'ColumnParallelEmbeddingBag', 'FusedHybridParallelEmbeddingBag', 'ParallelQREmbedding', 'LoadBalanceManager',
-    'ParallelMixVocabEmbeddingBag', 'BlockEmbeddingBag', 'CacheReplacePolicy', 'CachedEmbeddingBag'
+    'ParallelMixVocabEmbeddingBag', 'BlockEmbeddingBag', 'CacheReplacePolicy', 'CachedEmbeddingBag',
+    'ParallelCachedEmbeddingBag'
 ]

--- a/recsys/modules/embeddings/cached_embeddings.py
+++ b/recsys/modules/embeddings/cached_embeddings.py
@@ -6,11 +6,59 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from recsys import DISTMGR, ParallelMode, DISTLogger as logger
+from recsys.utils import get_partition
+from ..functional import dual_all_to_all
+
 
 class CacheReplacePolicy(enum.Enum):
     Hash = 0    # "hash"
     LFU = 1    # "least frequently used"
     LRU = 2    # "least recently used"
+
+
+def find_eligible_positions_hash(miss_ids, hit_ids, cache_indices, cache_states=None):
+    """
+    hash solution
+    """
+    positions, rehash_count, write_back_positions = [], 0, []
+    for each in miss_ids:
+        pos = -1
+        for i in itertools.count():
+            pos = hash_func(each, cache_indices.shape[0], pos, i)
+            if cache_indices[pos] not in hit_ids and pos not in positions:
+                rehash_count += i
+                positions.append(pos)
+                if cache_indices[pos] >= 0:
+                    write_back_positions.append(pos)
+                break
+    positions = torch.tensor(positions, dtype=miss_ids.dtype, device=miss_ids.device)
+    write_back_positions = torch.tensor(write_back_positions, dtype=miss_ids.dtype, device=miss_ids.device)
+    return positions, write_back_positions, rehash_count
+
+
+def hash_func(embed_id, N, prev, rehash_count):
+    return hash((embed_id, prev, rehash_count)) % N
+
+
+def find_eligible_positions_lfu(miss_ids, forbidden_list, cache_indices, cache_states):
+    """
+    LFU cache replacement policy
+    """
+    positions, write_back_positions = [], []
+    sorted_freq, sorted_idx = torch.sort(cache_states)
+    for freq, idx in zip(sorted_freq, sorted_idx):
+        if cache_indices[idx] in forbidden_list:
+            continue
+        positions.append(idx)
+        if freq >= 0:
+            write_back_positions.append(idx)
+        if len(positions) == miss_ids.shape[0]:
+            break
+
+    positions = torch.tensor(positions, dtype=miss_ids.dtype, device=miss_ids.device)
+    write_back_positions = torch.tensor(write_back_positions, dtype=miss_ids.dtype, device=miss_ids.device)
+    return positions, write_back_positions, 0
 
 
 class CachedEmbeddingBag(nn.Module):
@@ -89,6 +137,8 @@ class CachedEmbeddingBag(nn.Module):
     @torch.no_grad()
     def init_parameters(self):
         self.weight.data.uniform_(-1 / self.num_embeddings, 1 / self.num_embeddings)
+        if self.padding_idx is not None:
+            self.weight[self.padding_idx].fill_(0)
 
     def forward(self, indices, offsets=None, per_sample_weights=None):
         # NOTE: we only support 1-dim indices with offsets for storage & communication efficiency
@@ -194,58 +244,204 @@ class CachedEmbeddingBag(nn.Module):
         return embedding_bag
 
 
-class ColumnParallelCachedEmbeddingBag(nn.Module):
+class ParallelCachedEmbeddingBag(nn.Module):
 
-    def __init__(self):
-        pass
+    def __init__(self,
+                 num_embeddings,
+                 embedding_dim,
+                 cache_sets,
+                 padding_idx=None,
+                 max_norm=None,
+                 norm_type=2.,
+                 scale_grad_by_freq=False,
+                 sparse=False,
+                 _weight=None,
+                 mode='mean',
+                 include_last_offset=False,
+                 cache_lines=1,
+                 cache_replace_policy=CacheReplacePolicy.LFU,
+                 parallel_mode=ParallelMode.DEFAULT,
+                 device=None,
+                 dtype=None,
+                 debug=True):
+        super(ParallelCachedEmbeddingBag, self).__init__()
+        self.num_embeddings = num_embeddings
+        self.embedding_dim = embedding_dim
 
-    def forward(self):
-        ...
+        if padding_idx is not None:
+            if padding_idx > 0:
+                assert padding_idx < self.num_embeddings, 'Padding_idx must be within num_embeddings'
+            elif padding_idx < 0:
+                assert padding_idx >= -self.num_embeddings, 'Padding_idx must be within num_embeddings'
+                padding_idx = self.num_embeddings + padding_idx
+        self.padding_idx = padding_idx
+        self.max_norm = max_norm
+        self.norm_type = norm_type
+        self.scale_grad_by_freq = scale_grad_by_freq
+        self.sparse = sparse
 
+        # Specific to embedding bag
+        self.mode = mode
+        self.include_last_offset = include_last_offset
 
-class HybridParallelCachedEmbeddingBag(ColumnParallelCachedEmbeddingBag):
-    pass
+        # Specific to cache
+        self.cache_sets = cache_sets
+        self.cache_lines = cache_lines    # TODO: n-way set associative
+        self.cache_replace_policy = cache_replace_policy
+        self.debug = debug
 
+        # Comm settings
+        self.parallel_mode = parallel_mode
+        self.rank = DISTMGR.get_rank(self.parallel_mode)
+        self.world_size = DISTMGR.get_world_size(self.parallel_mode)
 
-def find_eligible_positions_hash(miss_ids, hit_ids, cache_indices, cache_states=None):
-    """
-    hash solution
-    """
-    positions, rehash_count, write_back_positions = [], 0, []
-    for each in miss_ids:
-        pos = -1
-        for i in itertools.count():
-            pos = hash_func(each, cache_indices.shape[0], pos, i)
-            if cache_indices[pos] not in hit_ids and pos not in positions:
-                rehash_count += i
-                positions.append(pos)
-                if cache_indices[pos] >= 0:
-                    write_back_positions.append(pos)
-                break
-    positions = torch.tensor(positions, dtype=miss_ids.dtype, device=miss_ids.device)
-    write_back_positions = torch.tensor(write_back_positions, dtype=miss_ids.dtype, device=miss_ids.device)
-    return positions, write_back_positions, rehash_count
+        self.chunk_start_index, self.chunk_end_index, divisible = get_partition(embedding_dim, self.rank,
+                                                                                self.world_size)
+        self.embedding_dim_per_partition = self.chunk_end_index - self.chunk_start_index
+        if debug:
+            logger.info(f"init [{self.chunk_start_index}, {self.chunk_end_index}) chunk of "
+                        f"{num_embeddings} x {embedding_dim} in rank {self.rank} / {self.world_size}")
+        if _weight is None:
+            self.weight = torch.empty(self.num_embeddings, self.embedding_dim_per_partition, device='cpu', dtype=dtype)
+            self.init_parameters()
+        else:
+            assert list(_weight.shape) == [num_embeddings, embedding_dim]
+            chunk = torch.tensor_split(_weight, self.world_size, 1)[self.rank]
+            assert list(chunk.shape) == [num_embeddings, self.embedding_dim_per_partition]
+            self.weight = chunk
 
+        # embedding cached in GPU for training
+        self.cache_weight = nn.Parameter(
+            torch.zeros(cache_sets * cache_lines, self.embedding_dim_per_partition, device=device, dtype=dtype))
+        self.register_buffer("cache_indices",
+                             torch.empty(cache_sets * cache_lines, device=device, dtype=torch.long).fill_(-1))
 
-def hash_func(embed_id, N, prev, rehash_count):
-    return hash((embed_id, prev, rehash_count)) % N
+        if cache_replace_policy == CacheReplacePolicy.Hash:
+            # just a placeholder
+            self.register_buffer("cache_states", torch.zeros(1, device=device, dtype=torch.long), persistent=False)
+            self._find_eligible_positions = find_eligible_positions_hash
+        else:
+            self.register_buffer("cache_states",
+                                 torch.empty(cache_sets * cache_lines, device=device, dtype=torch.long).fill_(-1))
+            if cache_replace_policy == CacheReplacePolicy.LFU:
+                self._find_eligible_positions = find_eligible_positions_lfu
+            else:
+                raise NotImplementedError("I haven't implemented LRU policy...")
 
+    @torch.no_grad()
+    def init_parameters(self):
+        self.weight.data.uniform_(-1 / self.num_embeddings, 1 / self.num_embeddings)
+        if self.padding_idx is not None:
+            self.weight[self.padding_idx].fill_(0)
 
-def find_eligible_positions_lfu(miss_ids, forbidden_list, cache_indices, cache_states):
-    """
-    LFU cache replacement policy
-    """
-    positions, write_back_positions = [], []
-    sorted_freq, sorted_idx = torch.sort(cache_states)
-    for freq, idx in zip(sorted_freq, sorted_idx):
-        if cache_indices[idx] in forbidden_list:
-            continue
-        positions.append(idx)
-        if freq >= 0:
-            write_back_positions.append(idx)
-        if len(positions) == miss_ids.shape[0]:
-            break
+    def forward(self, indices, offsets=None, per_sample_weights=None, send_shape=None, scatter_dim=0, gather_dim=-1):
+        indices = self.reorder_input_indices(indices)
 
-    positions = torch.tensor(positions, dtype=miss_ids.dtype, device=miss_ids.device)
-    write_back_positions = torch.tensor(write_back_positions, dtype=miss_ids.dtype, device=miss_ids.device)
-    return positions, write_back_positions, 0
+        output_shard = F.embedding_bag(indices, self.cache_weight, offsets, self.max_norm, self.norm_type,
+                                       self.scale_grad_by_freq, self.mode, self.sparse, per_sample_weights,
+                                       self.include_last_offset, self.padding_idx)
+        if send_shape is not None:
+            output_shard = output_shard.view(*send_shape)
+
+        # TODO: async communication
+        return dual_all_to_all(output_shard, self.parallel_mode, scatter_dim=scatter_dim, gather_dim=gather_dim)
+
+    @torch.no_grad()
+    def reorder_input_indices(self, raw_indices):
+        unique_indices, inverse_indices, counts = torch.unique(raw_indices, return_inverse=True, return_counts=True)
+        assert unique_indices.shape[0] <= self.cache_weight.shape[0], \
+            f"the num of input ids {unique_indices.shape[0]} is larger than " \
+            f"the cache size {self.cache_weight.shape[0]}, please increase the cache size or shrink the batch size"
+
+        unique_miss = unique_indices[torch.isin(unique_indices, self.cache_indices, invert=True)]
+        unique_hit = unique_indices[torch.isin(unique_indices, unique_miss, assume_unique=True, invert=True)]
+
+        rehash_count, write_back_count = 0, 0
+        if unique_miss.shape[0] > 0:
+            positions_miss, write_back_positions, rehash_count = self._find_eligible_positions(
+                unique_miss, unique_hit, self.cache_indices, self.cache_states)
+
+            assert positions_miss.shape[0] == unique_miss.shape[0], \
+                f"pos: {positions_miss.shape[0]}, unique: {unique_miss.shape[0]}"
+            write_back_count = write_back_positions.shape[0]
+            self._update_cache_(positions_miss, write_back_positions, unique_miss)
+
+        if self.debug:
+            logger.info(
+                f"miss count: #{unique_miss.shape[0]}, rehash count: #{rehash_count}, "
+                f"write back count: #{write_back_count}",
+                ranks=[0])
+        return self._map_indices(unique_indices, inverse_indices, counts)
+
+    def _update_cache_(self, positions_miss, write_back_positions, unique_miss):
+        # update cpu embedding: write cached gpu embeddings back to cpu
+        write_back_embedding_indices = self.cache_indices[write_back_positions]
+        write_back_embeddings = self.cache_weight[write_back_positions].cpu()
+        self.weight.data[write_back_embedding_indices] = write_back_embeddings
+
+        # update gpu embedding cache: move missing embeddings from cpu to gpu cache
+        new_embeddings = torch.index_select(self.weight, dim=0, index=unique_miss.cpu()).cuda()
+        self.cache_weight.data[positions_miss] = new_embeddings
+
+        # update cache indices
+        self.cache_indices.data[positions_miss] = unique_miss
+
+        # update (optional) cache states
+        if self.cache_replace_policy == CacheReplacePolicy.LFU:
+            self.cache_states.data[positions_miss] = -1
+        elif self.cache_replace_policy == CacheReplacePolicy.LRU:
+            raise NotImplementedError()
+
+    def _map_indices(self, unique_indices, inverse_indices, counts):
+        cache_indices = self.cache_indices.tolist()
+        local_indices = torch.tensor([cache_indices.index(x.item()) for x in unique_indices],
+                                     dtype=unique_indices.dtype,
+                                     device=unique_indices.device)
+        if self.cache_replace_policy == CacheReplacePolicy.LFU:
+            self.cache_states.data[local_indices] += counts
+        return local_indices[inverse_indices]
+
+    @torch.no_grad()
+    def flush_cache_(self):
+        cache_mask = self.cache_indices >= 0
+        embed_indices = self.cache_indices[cache_mask].cpu()
+        local_indices = torch.nonzero(cache_mask).squeeze(1)
+        cache_weight = torch.index_select(self.cache_weight, dim=0, index=local_indices).cpu()
+        self.weight.data[embed_indices] = cache_weight
+
+    @classmethod
+    def from_pretrained(cls,
+                        embeddings: torch.Tensor,
+                        cache_sets: int,
+                        freeze: bool = True,
+                        padding_idx: Optional[int] = None,
+                        max_norm: Optional[float] = None,
+                        norm_type: float = 2.,
+                        scale_grad_by_freq: bool = False,
+                        sparse: bool = False,
+                        mode: str = 'mean',
+                        include_last_offset: bool = False,
+                        cache_lines=1,
+                        cache_replace_policy=CacheReplacePolicy.LFU,
+                        parallel_mode=ParallelMode.DEFAULT,
+                        debug=True) -> 'ParallelCachedEmbeddingBag':
+        assert embeddings.dim() == 2, \
+            'Embeddings parameter is expected to be 2-dimensional'
+        rows, cols = embeddings.shape
+        embedding_bag = cls(rows,
+                            cols,
+                            cache_sets,
+                            padding_idx=padding_idx,
+                            max_norm=max_norm,
+                            norm_type=norm_type,
+                            scale_grad_by_freq=scale_grad_by_freq,
+                            sparse=sparse,
+                            _weight=embeddings,
+                            mode=mode,
+                            include_last_offset=include_last_offset,
+                            cache_lines=cache_lines,
+                            cache_replace_policy=cache_replace_policy,
+                            parallel_mode=parallel_mode,
+                            debug=debug)
+        embedding_bag.cache_weight.requires_grad = not freeze
+        return embedding_bag

--- a/recsys/testing/__init__.py
+++ b/recsys/testing/__init__.py
@@ -1,0 +1,3 @@
+from .utils import rerun_if_address_is_in_use, free_port
+
+__all__ = ['rerun_if_address_is_in_use', 'free_port']

--- a/recsys/testing/utils.py
+++ b/recsys/testing/utils.py
@@ -1,0 +1,133 @@
+import re
+from typing import Callable
+from inspect import signature
+from packaging import version
+import socket
+import random
+
+import torch
+
+
+def rerun_on_exception(exception_type: Exception = Exception, pattern: str = None, max_try: int = 5) -> Callable:
+    """
+    A decorator on a function to re-run when an exception occurs.
+
+    Usage::
+
+        # rerun for all kinds of exception
+        @rerun_on_exception()
+        def test_method():
+            print('hey')
+            raise RuntimeError('Address already in use')
+
+        # rerun for RuntimeError only
+        @rerun_on_exception(exception_type=RuntimeError)
+        def test_method():
+            print('hey')
+            raise RuntimeError('Address already in use')
+
+        # rerun for maximum 10 times if Runtime error occurs
+        @rerun_on_exception(exception_type=RuntimeError, max_try=10)
+        def test_method():
+            print('hey')
+            raise RuntimeError('Address already in use')
+
+        # rerun for infinite times if Runtime error occurs
+        @rerun_on_exception(exception_type=RuntimeError, max_try=None)
+        def test_method():
+            print('hey')
+            raise RuntimeError('Address already in use')
+
+        # rerun only the exception message is matched with pattern
+        # for infinite times if Runtime error occurs
+        @rerun_on_exception(exception_type=RuntimeError, pattern="^Address.*$")
+        def test_method():
+            print('hey')
+            raise RuntimeError('Address already in use')
+
+    Args:
+        exception_type (Exception, Optional): The type of exception to detect for rerun
+        pattern (str, Optional): The pattern to match the exception message.
+            If the pattern is not None and matches the exception message,
+            the exception will be detected for rerun
+        max_try (int, Optional): Maximum reruns for this function. The default value is 5.
+            If max_try is None, it will rerun foreven if exception keeps occurings
+    """
+
+    def _match_lines(lines, pattern):
+        for line in lines:
+            if re.match(pattern, line):
+                return True
+        return False
+
+    def _wrapper(func):
+
+        def _run_until_success(*args, **kwargs):
+            try_count = 0
+            assert max_try is None or isinstance(max_try, int), \
+                f'Expected max_try to be None or int, but got {type(max_try)}'
+
+            while max_try is None or try_count < max_try:
+                try:
+                    try_count += 1
+                    ret = func(*args, **kwargs)
+                    return ret
+                except exception_type as e:
+                    error_lines = str(e).split('\n')
+                    if try_count < max_try and (pattern is None or _match_lines(error_lines, pattern)):
+                        print('Exception is caught, retrying...')
+                        # when pattern is not specified, we always skip the exception
+                        # when pattern is specified, we only skip when pattern is matched
+                        continue
+                    else:
+                        print('Maximum number of attempts is reached or pattern is not matched, no more retrying...')
+                        raise e
+
+        # Override signature
+        # otherwise pytest.mark.parameterize will raise the following error:
+        # function does not use argumetn xxx
+        sig = signature(func)
+        _run_until_success.__signature__ = sig
+
+        return _run_until_success
+
+    return _wrapper
+
+
+def rerun_if_address_is_in_use():
+    """
+    This function reruns a wrapped function if "address already in use" occurs
+    in testing spawned with torch.multiprocessing
+
+    Usage::
+
+        @rerun_if_address_is_in_use()
+        def test_something():
+            ...
+
+    """
+    # check version
+    torch_version = version.parse(torch.__version__)
+    assert torch_version.major == 1
+
+    # only torch >= 1.8 has ProcessRaisedException
+    if torch_version.minor >= 8:
+        exception = torch.multiprocessing.ProcessRaisedException
+    else:
+        exception = Exception
+
+    func_wrapper = rerun_on_exception(exception_type=exception, pattern=".*Address already in use.*")
+    return func_wrapper
+
+
+def free_port():
+    while True:
+        try:
+            sock = socket.socket()
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            port = random.randint(20000, 65000)
+            sock.bind(('localhost', port))
+            sock.close()
+            return port
+        except Exception:
+            continue

--- a/recsys/utils/__init__.py
+++ b/recsys/utils/__init__.py
@@ -1,10 +1,4 @@
 from .launch import get_default_parser
-from .misc import get_mem_info, compute_throughput, get_time_elapsed, Timer
+from .misc import get_mem_info, compute_throughput, get_time_elapsed, Timer, get_partition
 
-__all__ = [
-    'get_default_parser', 
-    'get_mem_info', 
-    'compute_throughput', 
-    'get_time_elapsed', 
-    'Timer',
-]
+__all__ = ['get_default_parser', 'get_mem_info', 'compute_throughput', 'get_time_elapsed', 'Timer', 'get_partition']

--- a/tests/test_embeddings/cached_embedding_test.py
+++ b/tests/test_embeddings/cached_embedding_test.py
@@ -4,12 +4,10 @@ import numpy as np
 import torch
 import torch.multiprocessing as mp
 
-from colossalai.utils import free_port
-from colossalai.testing import rerun_if_address_is_in_use
-
 from recsys import launch, disable_existing_loggers
 from recsys import DISTMGR
-from recsys.modules.embeddings import CachedEmbeddingBag, CacheReplacePolicy
+from recsys.testing import rerun_if_address_is_in_use, free_port
+from recsys.modules.embeddings import CachedEmbeddingBag, ParallelCachedEmbeddingBag, CacheReplacePolicy
 
 NUM_EMBEDDINGS, EMBEDDING_DIM = 100, 8
 BATCH_SIZE = 8
@@ -20,8 +18,8 @@ def synthesize_sparse_feature(
     num_embed,
     device,
 ):
-    indices_in_batch = BATCH_SIZE * 2
-    indices = torch.randint(low=0, high=NUM_EMBEDDINGS, size=(indices_in_batch,), device=device, dtype=torch.long)
+    indices_in_batch = batch_size * 2
+    indices = torch.randint(low=0, high=num_embed, size=(indices_in_batch,), device=device, dtype=torch.long)
     offsets = torch.from_numpy(
         np.array([
             0, *np.sort(np.random.randint(low=0, high=indices_in_batch, size=(indices_in_batch - 1,))), indices_in_batch
@@ -42,7 +40,7 @@ def run_cached_embedding_bag(cache_replace_policy):
                                                mode='mean',
                                                include_last_offset=True,
                                                freeze=False).to(device)
-
+    assert model.weight.device.type == 'cpu'
     optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
     ref_optimizer = torch.optim.SGD(ref_model.parameters(), lr=1e-3)
 
@@ -68,11 +66,98 @@ def run_cached_embedding_bag(cache_replace_policy):
     assert torch.allclose(model_weight, ref_weight)
 
 
+def gather_tensor(tensor):
+    gather_list = []
+    rank = DISTMGR.get_rank()
+    world_size = DISTMGR.get_world_size()
+    if rank == 0:
+        gather_list = [torch.empty_like(tensor) for _ in range(world_size)]
+
+    group = DISTMGR.get_group()
+    torch.distributed.gather(tensor, gather_list, dst=0, group=group)
+    return gather_list
+
+
+def parallel_cached_embedding_bag(cache_replace_policy):
+    device = torch.device("cuda", torch.cuda.current_device())
+    rank = DISTMGR.get_rank()
+    world_size = DISTMGR.get_world_size()
+
+    # indivisible
+    weight = torch.randn(NUM_EMBEDDINGS, EMBEDDING_DIM, dtype=torch.float)
+    model = ParallelCachedEmbeddingBag.from_pretrained(weight.detach(),
+                                                       cache_sets=BATCH_SIZE * 2,
+                                                       cache_replace_policy=cache_replace_policy,
+                                                       mode='mean',
+                                                       include_last_offset=True,
+                                                       freeze=False).to(device)
+    assert model.weight.device.type == 'cpu'
+    weight_in_rank = torch.tensor_split(weight, world_size, 1)[rank]
+    assert torch.allclose(weight_in_rank, model.weight.detach())
+
+    optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
+
+    if rank == 0:
+        ref_model = torch.nn.EmbeddingBag.from_pretrained(weight.cuda(),
+                                                          mode='mean',
+                                                          include_last_offset=True,
+                                                          freeze=False)
+        ref_optimizer = torch.optim.SGD(ref_model.parameters(), lr=1e-3)
+
+    # sync RNG states
+    DISTMGR.set_seed(1234)
+    for i in range(4):
+        indices, offsets = synthesize_sparse_feature(BATCH_SIZE, NUM_EMBEDDINGS, device)
+        res = model(indices, offsets)
+
+        grad = torch.rand(BATCH_SIZE * 2, EMBEDDING_DIM, dtype=res.dtype, device=res.device)
+        grad_in_rank = torch.tensor_split(grad, world_size, 0)[rank]
+        res.backward(grad_in_rank)
+
+        optimizer.step()
+        optimizer.zero_grad()
+        model.flush_cache_()
+
+        res_list = gather_tensor(res.detach())
+        weight_list = gather_tensor(model.weight.detach().cuda())
+        # weight_str = '\n'.join([str((r, _w[:10])) for r, _w in enumerate(weight_list)])
+        if rank == 0:
+            ref_res = ref_model(indices, offsets)
+            recover_res = torch.cat(res_list, dim=0)
+            assert torch.allclose(ref_res.detach(), recover_res), f"model res: {recover_res}, ref res: {ref_res}"
+
+            ref_res.backward(grad)
+            ref_optimizer.step()
+            ref_optimizer.zero_grad()
+            # print(weight_str)
+            recover_weight = torch.cat(weight_list, dim=1)
+            # print(f"it {i}: model weight: {recover_weight[:10]}, ref weight: {ref_model.weight.detach()[:10]}")
+            assert torch.allclose(recover_weight, ref_model.weight.detach())
+
+
+def run_parallel_cached_embedding_bag(rank, world_size, port, cache_replace_policy):
+    disable_existing_loggers()
+    launch(rank=rank, world_size=world_size, host='localhost', port=port, backend='nccl')
+    parallel_cached_embedding_bag(cache_replace_policy)
+
+
 @pytest.mark.parametrize("cache_replace_policy", [CacheReplacePolicy.Hash, CacheReplacePolicy.LFU])
 def test_cached_embedding_bag(cache_replace_policy,):
     run_func = partial(run_cached_embedding_bag, cache_replace_policy=cache_replace_policy)
     run_func()
 
 
+@pytest.mark.parametrize('world_size', [1, 4])
+@pytest.mark.parametrize("cache_replace_policy", [CacheReplacePolicy.Hash, CacheReplacePolicy.LFU])
+@rerun_if_address_is_in_use()
+def test_parallel_cached_embedding_bag(world_size, cache_replace_policy):
+    run_func = partial(run_parallel_cached_embedding_bag,
+                       world_size=world_size,
+                       cache_replace_policy=cache_replace_policy,
+                       port=free_port())
+    mp.spawn(run_func, nprocs=world_size)
+
+
 if __name__ == "__main__":
-    test_cached_embedding_bag(CacheReplacePolicy.Hash)
+    # test_cached_embedding_bag(CacheReplacePolicy.Hash)
+    test_parallel_cached_embedding_bag(4, CacheReplacePolicy.LFU)


### PR DESCRIPTION
Add two modules in recsys: CachedEmbeddingBag & ParallelCachedEmbeddingBag.

CachedEmbeddingBag is a single-process version equal to torch.nn.EmbeddingBag; ParallelCachedEmbeddingBag is a parallel version which follows column-wise tensor parallelism and all-to-all communication.

Currently, they support two cache replacement policies: Hash & LFU

![image](https://user-images.githubusercontent.com/34452939/178653951-1b5e378e-16e6-46c2-a934-602738cf0ab7.png)
