### PR TITLE
[new feature] for tablewise, split indices and offsets along assinged_rank in DATALOADER.

### DIFF
--- a/recsys/datasets/avazu.py
+++ b/recsys/datasets/avazu.py
@@ -206,7 +206,7 @@ class InMemoryAvazuIterDataPipe(IterableDataset):
         return self.num_batches
 
 
-def get_dataloader(args, stage, rank, world_size):
+def get_dataloader(args, stage, rank, world_size,  assigned_tables = None):
     stage = stage.lower()
 
     files = os.listdir(args.dataset_dir)

--- a/recsys/datasets/criteo.py
+++ b/recsys/datasets/criteo.py
@@ -56,6 +56,9 @@ class InMemoryBinaryCriteoIterDataPipe(IterableDataset):
             Length of this list should be CAT_FEATURE_COUNT.
         path_manager_key (str): Path manager key used to load from different
             filesystems.
+        assigned_tables (Optional[List[int]]): For tablewise mode. sparse features(tables) are numbered as 0, 1, 2, ..., n. 
+                        appending a number to assigned_tables means the coresponding table is assinged to this loader.
+                        iff a table is assigned to this loader should it be loaded into the batch.
 
     Example::
 

--- a/recsys/datasets/criteo.py
+++ b/recsys/datasets/criteo.py
@@ -256,23 +256,38 @@ class PetastormDataReader(IterableDataset):
                  shuffle_batches=False,
                  hashes=None,
                  seed=1024,
-                 drop_last=True):
+                 drop_last=True,
+                 assigned_tables=None):
+        
+        if assigned_tables is not None:
+            # tablewise mode
+            self.assigned_tables = np.array(assigned_tables)
+        else:
+            # full table mode
+            self.assigned_tables = np.arange(CAT_FEATURE_COUNT)
         self.dataset = ParquetDataset(paths, use_legacy_dataset=False)
         self.batch_size = batch_size
         self.rank = rank
         self.world_size = world_size
         self.shuffle_batches = shuffle_batches
-        self.hashes = np.array(hashes).reshape((1, CAT_FEATURE_COUNT)) if hashes is not None else None
-        self.sparse_offsets = np.array([0, *np.cumsum(hashes)[:-1]], dtype=np.int64).reshape(-1, 1) \
-            if hashes is not None else None
+        if hashes is not None:
+            self.hashes = []
+            for i, length in enumerate(hashes):
+                if i in self.assigned_tables:
+                    self.hashes.append(length)
+            self.hashes = np.array(self.hashes).reshape(1, -1)
+        else:
+            self.hashes = None
+        self.sparse_offsets = np.array([0, *np.cumsum(self.hashes)[:-1]], dtype=np.int64).reshape(
+                    -1, 1) if self.hashes is not None else None
 
-        self._num_ids_in_batch: int = CAT_FEATURE_COUNT * batch_size
-        self.keys: List[str] = DEFAULT_CAT_NAMES
+        self._num_ids_in_batch: int = len(self.assigned_tables) * batch_size
+        self.keys: List[str] = [DEFAULT_CAT_NAMES[i] for i in self.assigned_tables]
         self.lengths: torch.Tensor = torch.ones((self._num_ids_in_batch,), dtype=torch.int32)
         self.offsets: torch.Tensor = torch.arange(0, self._num_ids_in_batch + 1, dtype=torch.int32)
         self.stride = batch_size
-        self.length_per_key: List[int] = CAT_FEATURE_COUNT * [batch_size]
-        self.offset_per_key: List[int] = [batch_size * i for i in range(CAT_FEATURE_COUNT + 1)]
+        self.length_per_key: List[int] = len(self.assigned_tables) * [batch_size]
+        self.offset_per_key: List[int] = [batch_size * i for i in range(len(self.assigned_tables) + 1)]
         self.index_per_key: Dict[str, int] = {key: i for (i, key) in enumerate(self.keys)}
         self.seed = seed
         self.epoch = 0
@@ -307,7 +322,7 @@ class PetastormDataReader(IterableDataset):
             # note that `batch` here is just a bunch of samples read by petastorm instead of `batch` consumed by models
             for batch in reader:
                 labels = getattr(batch, DEFAULT_LABEL_NAME)
-                sparse = np.concatenate([getattr(batch, col_name).reshape(1, -1) for col_name in DEFAULT_CAT_NAMES],
+                sparse = np.concatenate([getattr(batch, col_name).reshape(1, -1) for col_name in self.keys],
                                         axis=0)
                 if self.sparse_offsets is not None:
                     sparse = sparse + self.sparse_offsets
@@ -395,7 +410,7 @@ def _get_kaggle_dataloader(args, stage, rank, world_size, assigned_tables=None):
     return dataloader
 
 
-def _get_terabyte_dataloader(args, stage, rank, world_size):
+def _get_terabyte_dataloader(args, stage, rank, world_size, assigned_tables=None):
     # TODO: replace the data_split with stage
     if stage == "train":
         data_split = "train"
@@ -416,7 +431,8 @@ def _get_terabyte_dataloader(args, stage, rank, world_size):
                                                 world_size=None,
                                                 shuffle_batches=stage == "train",
                                                 hashes=args.num_embeddings_per_feature,
-                                                seed=args.seed),
+                                                seed=args.seed,
+                                                assigned_tables=assigned_tables),
                             batch_size=None,
                             pin_memory=False,
                             collate_fn=lambda x: x,
@@ -436,7 +452,7 @@ def get_dataloader(args, stage, rank, world_size, assigned_tables = None):
     if "kaggle" in args.dataset_dir:
         return _get_kaggle_dataloader(args, stage, rank, world_size, assigned_tables)
     else:
-        return _get_terabyte_dataloader(args, stage, rank, world_size)
+        return _get_terabyte_dataloader(args, stage, rank, world_size, assigned_tables)
 
 
 def get_id_freq_map(path):

--- a/recsys/dlrm_main.py
+++ b/recsys/dlrm_main.py
@@ -123,12 +123,6 @@ def parse_args():
                         default=500_000,
                         help="Number of cache sets in the cache. "
                         "*** Please make sure it can hold AT LEAST ONE BATCH OF SPARSE FEATURE IDS ***")
-    parser.add_argument(
-        "--cache_lines",
-        type=int,
-        default=1,
-        help="Number of cache lines in each cache set. Similar to the N-way set associate mechanism in cache."
-        "Not implemented yet. Increasing this would scale up the cache capacity")
     parser.add_argument("--use_freq", action='store_true',
                         help="use the dataset freq information to initialize the softwar cache")
     parser.add_argument("--use_lfu", action='store_true',
@@ -390,7 +384,6 @@ def main():
         fused_op=args.fused_op,
         use_cache=args.use_cache,
         cache_sets=args.cache_sets,
-        cache_lines=args.cache_lines,
         id_freq_map=id_freq_map,
         warmup_ratio=args.warmup_ratio,
         buffer_size=args.buffer_size,

--- a/recsys/dlrm_main.py
+++ b/recsys/dlrm_main.py
@@ -303,7 +303,7 @@ def train_val_test(
     train_val_test_results = TrainValTestResults()
     with profile(
             activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
-            schedule=schedule(wait=0, warmup=200, active=2, repeat=1),
+            schedule=schedule(wait=0, warmup=200, active=5, repeat=1),
             profile_memory=True,
             on_trace_ready=tensorboard_trace_handler(args.profile_dir),
     ) as prof:

--- a/recsys/dlrm_main.py
+++ b/recsys/dlrm_main.py
@@ -15,6 +15,8 @@ from recsys.utils import FiniteDataIter, TrainValTestResults
 
 import colossalai
 
+from utils import get_tablewise_rank_arrange
+
 dist_logger = colossalai.logging.get_dist_logger()
 
 
@@ -193,7 +195,7 @@ def put_data_in_device(batch, dense_device, sparse_device, is_dist=False, rank=0
         sparse_features = batch.sparse_features.to(sparse_device)
         return dense_features, sparse_features, labels
 
-
+    
 def _train(model,
            optimizer,
            criterion,
@@ -347,6 +349,15 @@ def main():
     dist_logger.info(f"launch rank: {rank} / {world_size}")
     dist_logger.info(f"config: {args}", ranks=[0])
 
+    assigned_tables = None
+    if args.use_tablewise:
+        rank_arrange = None
+        rank_arrange = get_tablewise_rank_arrange(args.dataset_dir, torch.distributed.get_world_size())
+        assigned_tables = []
+        for table, assign_rank in enumerate(rank_arrange):
+            if assign_rank == torch.distributed.get_rank():
+                assigned_tables.append(table)
+    
     if 'criteo' in args.dataset_dir:
         data_module = criteo
     elif 'avazu' in args.dataset_dir:
@@ -354,9 +365,9 @@ def main():
     else:
         raise NotImplementedError()    # TODO: random data interface
 
-    train_dataloader = data_module.get_dataloader(args, 'train', **dataloader_factory)
-    val_dataloader = data_module.get_dataloader(args, "val", **dataloader_factory)
-    test_dataloader = data_module.get_dataloader(args, "test", **dataloader_factory)
+    train_dataloader = data_module.get_dataloader(args, 'train', **dataloader_factory, assigned_tables = assigned_tables)
+    val_dataloader = data_module.get_dataloader(args, "val", **dataloader_factory, assigned_tables = assigned_tables)
+    test_dataloader = data_module.get_dataloader(args, "test", **dataloader_factory, assigned_tables = assigned_tables)
 
     if args.dataset_dir is not None and hasattr(train_dataloader, "__len__"):
         dist_logger.info(

--- a/recsys/models/dlrm.py
+++ b/recsys/models/dlrm.py
@@ -42,8 +42,12 @@ def prepare_tablewise_config(num_embeddings_per_feature,
             rank_arrange = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         elif world_size == 2:
             rank_arrange = [0, 1, 0, 1, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1, 1, 1, 0, 1, 0]
+        elif world_size == 3:
+            rank_arrange = [2, 1, 0, 1, 1, 2, 2, 1, 0, 0, 1, 1, 0, 1, 0, 2, 0, 2, 2, 0, 2, 2, 0, 1, 1, 0]
         elif world_size == 4:
             rank_arrange = [3, 1, 0, 3, 1, 0, 2, 1, 0, 2, 3, 1, 3, 1, 2, 3, 1, 2, 3, 0, 2, 0, 0, 2, 3, 2]
+        elif world_size == 8:
+            rank_arrange = [6, 6, 0, 4, 7, 2, 5, 7, 0, 5, 7, 1, 7, 3, 5, 3, 1, 6, 6, 0, 2, 2, 1, 4, 3, 4]
         else :
             raise NotImplementedError("Other Tablewise settings are under development")
 
@@ -102,6 +106,9 @@ class FusedSparseModules(nn.Module):
                     sparse=sparse,
                     mode=reduction_mode,
                     include_last_offset=True,
+                    cuda_row_num=cache_sets,
+                    warmup_ratio=warmup_ratio,
+                    buffer_size=buffer_size,
                     evict_strategy=EvictionStrategy.LFU if use_lfu_eviction else EvictionStrategy.DATASET
                 )
                 self.shape_hook = sparse_embedding_shape_hook_for_tablewise

--- a/recsys/utils/__init__.py
+++ b/recsys/utils/__init__.py
@@ -1,8 +1,9 @@
 from .misc import get_mem_info, compute_throughput, get_time_elapsed, Timer, get_partition, \
-    TrainValTestResults, count_parameters
+    TrainValTestResults, count_parameters, prepare_tablewise_config, get_tablewise_rank_arrange
 from .dataloader import CudaStreamDataIter, FiniteDataIter
 
 __all__ = [
     'get_mem_info', 'compute_throughput', 'get_time_elapsed', 'Timer', 'get_partition', 'CudaStreamDataIter',
-    'FiniteDataIter', 'TrainValTestResults', 'count_parameters'
+    'FiniteDataIter', 'TrainValTestResults', 'count_parameters', 'prepare_tablewise_config',
+    'get_tablewise_rank_arrange'
 ]

--- a/recsys/utils/misc.py
+++ b/recsys/utils/misc.py
@@ -5,7 +5,9 @@ import time
 from time import perf_counter
 from dataclasses import dataclass, field
 from typing import List, Optional
+from colossalai.nn.parallel.layers import TablewiseEmbeddingBagConfig
 
+import numpy as np
 
 @dataclass
 class TrainValTestResults:
@@ -150,3 +152,58 @@ def get_partition(embedding_dim, rank, world_size):
     size_list = [chunk_size + 1 if i < threshold else chunk_size for i in range(world_size)]
     offset = sum(size_list[:rank])
     return offset, offset + size_list[rank], False
+
+
+def prepare_tablewise_config(num_embeddings_per_feature,
+                             cache_ratio,
+                             id_freq_map_total=None,
+                             dataset="criteo_kaggle",
+                             world_size=2):
+    # WARNING, prototype. only support criteo_kaggle dataset and world_size == 2, 4
+    # TODO: automatic arrange
+    embedding_bag_config_list: List[TablewiseEmbeddingBagConfig] = []
+    rank_arrange = get_tablewise_rank_arrange(dataset, world_size)
+    table_offsets = np.array([0, *np.cumsum(num_embeddings_per_feature)])
+    for i, num_embeddings in enumerate(num_embeddings_per_feature):
+        ids_freq_mapping = None
+        if id_freq_map_total != None:
+            ids_freq_mapping = id_freq_map_total[table_offsets[i] : table_offsets[i + 1]]
+        cuda_row_num = int(cache_ratio * num_embeddings) + 2000
+        if cuda_row_num > num_embeddings:
+            cuda_row_num = num_embeddings
+        embedding_bag_config_list.append(
+            TablewiseEmbeddingBagConfig(
+                num_embeddings=num_embeddings,
+                cuda_row_num=cuda_row_num,
+                assigned_rank=rank_arrange[i],
+                ids_freq_mapping=ids_freq_mapping
+            )
+        )
+    return embedding_bag_config_list
+
+def get_tablewise_rank_arrange(dataset=None, world_size=0):
+    if 'criteo' in dataset and 'kaggle' in dataset:
+        if world_size == 1:
+            rank_arrange = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        elif world_size == 2:
+            rank_arrange = [0, 1, 0, 1, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1, 1, 1, 0, 1, 0]
+        elif world_size == 3:
+            rank_arrange = [2, 1, 0, 1, 1, 2, 2, 1, 0, 0, 1, 1, 0, 1, 0, 2, 0, 2, 2, 0, 2, 2, 0, 1, 1, 0]
+        elif world_size == 4:
+            rank_arrange = [3, 1, 0, 3, 1, 0, 2, 1, 0, 2, 3, 1, 3, 1, 2, 3, 1, 2, 3, 0, 2, 0, 0, 2, 3, 2]
+        elif world_size == 8:
+            rank_arrange = [6, 6, 0, 4, 7, 2, 5, 7, 0, 5, 7, 1, 7, 3, 5, 3, 1, 6, 6, 0, 2, 2, 1, 4, 3, 4]
+        else :
+            raise NotImplementedError("Other Tablewise settings are under development")
+    elif 'criteo' in dataset:
+        if world_size == 1:
+            rank_arrange = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        elif world_size == 2:
+            rank_arrange = [1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0]
+        elif world_size == 4:
+            rank_arrange = [1, 3, 3, 3, 3, 0, 2, 2, 1, 2, 2, 2, 0, 1, 2, 1, 0, 1, 0, 0, 2, 3, 3, 3, 1, 0]
+        else :
+            raise NotImplementedError("Other Tablewise settings are under development")
+    else:
+        raise NotImplementedError("Other Tablewise settings are under development")
+    return rank_arrange

--- a/scripts/kaggle.sh
+++ b/scripts/kaggle.sh
@@ -7,6 +7,27 @@ export DATAPATH=/data/criteo_kaggle_data/
 export GPUNUM=4
 export BATCHSIZE=16384
 export CACHESIZE=337625
+export USE_LFU=1
+export USE_TABLE_SHARD=1
+
+if [[ ${USE_LFU} == 1 ]];  then
+LFU_FLAG="--use_lfu"
+else
+export LFU_FLAG=""
+fi
+
+
+if [[ ${USE_TABLE_SHARD} == 1 ]];  then
+TABLE_SHARD_FLAG="--use_tablewise"
+else
+export TABLE_SHARD_FLAG=""
+fi
+
+
+torchx run -s local_cwd -cfg log_dir=log/kaggle/w${GPUNUM}_p1_16k dist.ddp -j 1x${GPUNUM} --script recsys/dlrm_main.py -- \
+    --dataset_dir ${DATAPATH} --pin_memory --shuffle_batches \
+    --learning_rate 1. --batch_size ${BATCHSIZE} --use_sparse_embed_grad --use_cache ${LFU_FLAG} ${TABLE_SHARD_FLAG} \
+    --profile_dir "tensorboard_log/kaggle/w${GPUNUM}_p1_${BATCHSIZE}"  --buffer_size 0 --use_overlap --cache_sets ${CACHESIZE} 2>&1 | tee logs/colo_${GPUNUM}_${BATCHSIZE}_${CACHESIZE}_lfu_${USE_LFU}_tw_${USE_TABLE_SHARD}.txt
 torchx run -s local_cwd -cfg log_dir=log/kaggle/w${GPUNUM}_p1_16k dist.ddp -j 1x${GPUNUM} --script recsys/dlrm_main.py -- \
     --dataset_dir ${DATAPATH} --pin_memory --shuffle_batches \
     --learning_rate 1. --batch_size ${BATCHSIZE} --use_sparse_embed_grad --use_cache --use_freq --use_lfu \

--- a/scripts/kaggle.sh
+++ b/scripts/kaggle.sh
@@ -2,8 +2,8 @@
 
 # For Colossalai enabled recsys
 # criteo kaggle
-# export DATAPATH=/data/scratch/RecSys/criteo_kaggle_data/
-export DATAPATH=/data/criteo_kaggle_data/
+export DATAPATH=/data/scratch/RecSys/criteo_kaggle_data/
+# export DATAPATH=/data/criteo_kaggle_data/
 export GPUNUM=4
 export BATCHSIZE=16384
 export CACHESIZE=337625

--- a/scripts/kaggle.sh
+++ b/scripts/kaggle.sh
@@ -4,10 +4,10 @@
 # criteo kaggle
 export DATAPATH=/data/scratch/RecSys/criteo_kaggle_data/
 # export DATAPATH=/data/criteo_kaggle_data/
-export GPUNUM=4
+export GPUNUM=2
 export BATCHSIZE=16384
 export CACHESIZE=337625
-export USE_LFU=1
+export USE_LFU=0
 export USE_TABLE_SHARD=1
 
 if [[ ${USE_LFU} == 1 ]];  then
@@ -28,7 +28,7 @@ torchx run -s local_cwd -cfg log_dir=log/kaggle/w${GPUNUM}_p1_16k dist.ddp -j 1x
     --dataset_dir ${DATAPATH} --pin_memory --shuffle_batches \
     --learning_rate 1. --batch_size ${BATCHSIZE} --use_sparse_embed_grad --use_cache ${LFU_FLAG} ${TABLE_SHARD_FLAG} \
     --profile_dir "tensorboard_log/kaggle/w${GPUNUM}_p1_${BATCHSIZE}"  --buffer_size 0 --use_overlap --cache_sets ${CACHESIZE} 2>&1 | tee logs/colo_${GPUNUM}_${BATCHSIZE}_${CACHESIZE}_lfu_${USE_LFU}_tw_${USE_TABLE_SHARD}.txt
-torchx run -s local_cwd -cfg log_dir=log/kaggle/w${GPUNUM}_p1_16k dist.ddp -j 1x${GPUNUM} --script recsys/dlrm_main.py -- \
-    --dataset_dir ${DATAPATH} --pin_memory --shuffle_batches \
-    --learning_rate 1. --batch_size ${BATCHSIZE} --use_sparse_embed_grad --use_cache --use_freq --use_lfu \
-     --profile_dir "tensorboard_log/kaggle/w${GPUNUM}_p1_16k"  --buffer_size 0 --use_overlap --cache_sets ${CACHESIZE} 2>&1 | tee logs/colo_${GPUNUM}_${BATCHSIZE}_${CACHESIZE}.txt
+# torchx run -s local_cwd -cfg log_dir=log/kaggle/w${GPUNUM}_p1_16k dist.ddp -j 1x${GPUNUM} --script recsys/dlrm_main.py -- \
+#     --dataset_dir ${DATAPATH} --pin_memory --shuffle_batches \
+#     --learning_rate 1. --batch_size ${BATCHSIZE} --use_sparse_embed_grad --use_cache --use_freq --use_lfu \
+#      --profile_dir "tensorboard_log/kaggle/w${GPUNUM}_p1_16k"  --buffer_size 0 --use_overlap --cache_sets ${CACHESIZE} 2>&1 | tee logs/colo_${GPUNUM}_${BATCHSIZE}_${CACHESIZE}.txt


### PR DESCRIPTION
criteo kaggle and criteo terabyte dataloader have been modified.

In tablewise mode, no more need to split indices and offsets, and reconcatente then while forwarding. 